### PR TITLE
fix: resolve Windows path separator issues in ls/find commands

### DIFF
--- a/cmd/vkfs/main.go
+++ b/cmd/vkfs/main.go
@@ -110,8 +110,15 @@ var catCmd = &cobra.Command{
 }
 
 var findCmd = &cobra.Command{
-	Use:   "find <path> -name <pattern>",
-	Short: "Search for files matching a pattern",
+	Use:   "find <path> --name <pattern>",
+	Short: "Search for files matching a glob pattern",
+	Long: `Search for files matching a glob pattern under the given path.
+
+Note: Use --name (double dash) to specify the pattern.
+
+Examples:
+  vkfs find / --name "*.md"        # find all .md files
+  vkfs find /docs --name "*.go"    # find .go files under /docs`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return fmt.Errorf("path required")
@@ -120,7 +127,7 @@ var findCmd = &cobra.Command{
 		path := args[0]
 		pattern, _ := cmd.Flags().GetString("name")
 		if pattern == "" {
-			return fmt.Errorf("-name flag required")
+			return fmt.Errorf("--name flag required")
 		}
 
 		fs, err := initFS()
@@ -133,7 +140,6 @@ var findCmd = &cobra.Command{
 			return err
 		}
 
-		// Print results
 		for _, result := range results {
 			fmt.Println(result)
 		}
@@ -337,7 +343,7 @@ func initFS() (*vfs.VirtualFS, error) {
 
 func init() {
 	// Add flags
-	findCmd.Flags().StringP("name", "n", "", "filename pattern (glob)")
+	findCmd.Flags().String("name", "", "filename pattern (glob)")
 	searchCmd.Flags().Int("top-k", 10, "number of results to return")
 	benchCmd.Flags().String("data-dir", "", "path to dataset directory with corpus.jsonl and queries.jsonl")
 	benchCmd.Flags().String("config", "", "path to VKFS config file")

--- a/pkg/vfs/fs.go
+++ b/pkg/vfs/fs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	stdpath "path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -116,7 +117,7 @@ func (fs *VirtualFS) buildIndexes() {
 			continue // root has no parent
 		}
 
-		parent := filepath.Dir(path)
+		parent := stdpath.Dir(path)
 		if parent == "." {
 			parent = "/"
 		}
@@ -152,7 +153,7 @@ func (fs *VirtualFS) Ls(path string) ([]VirtualNode, error) {
 	// Build result
 	result := make([]VirtualNode, 0, len(childNames))
 	for _, name := range childNames {
-		childPath := filepath.Join(path, name)
+		childPath := stdpath.Join(path, name)
 		if path == "/" {
 			childPath = "/" + name
 		}
@@ -212,7 +213,7 @@ func (fs *VirtualFS) Find(rootPath string, pattern string) ([]string, error) {
 		}
 
 		// Check if filename matches pattern
-		matched, err := filepath.Match(pattern, node.Name)
+		matched, err := stdpath.Match(pattern, node.Name)
 		if err != nil {
 			return nil, fmt.Errorf("invalid pattern: %w", err)
 		}


### PR DESCRIPTION
## Summary

- 修复 Windows 上 `vkfs ls` 和 `vkfs find` 命令无输出的两个 bug
- 将虚拟文件系统路径操作从 `filepath` 包切换到 `path` 包
- 修复 `find` 命令的 `-name` 标志解析问题

## Bug 1: `filepath` 在 Windows 上使用反斜杠（`pkg/vfs/fs.go`）

`buildIndexes()` 使用 `filepath.Dir()` 计算父目录路径。在 Windows 上 `filepath.Dir("/docs/readme.md")` 返回 `\docs`（反斜杠），但虚拟文件系统路径始终使用 `/`（正斜杠）。导致子节点被索引到错误的 key 下（如 `pathIndex["\docs"]` 而非 `pathIndex["/docs"]`），`ls` 查找时匹配不到任何子节点。

**验证：**
```go
filepath.Dir("/docs/readme.md")  // Windows → "\docs" ❌
path.Dir("/docs/readme.md")      // 所有平台 → "/docs" ✅
```

**修复：** 将 `filepath.Dir`、`filepath.Join`、`filepath.Match` 替换为 `path` 包对应函数（通过 `stdpath` 别名导入，避免与循环变量 `path` 冲突）。仅影响虚拟路径操作，本地文件系统路径（如 `Ingest` 中）仍使用 `filepath`。

## Bug 2: pflag 将 `-name` 解析为 `-n ame`（`cmd/vkfs/main.go`）

Cobra/pflag 将 `-name` 解析为短标志 `-n`（值为 `ame`），而非长标志 `--name`。导致 `find / -name "*.md"` 实际搜索 pattern 为 `"ame"`，自然匹配不到任何文件。

```
[DEBUG] args=[/ *.md] pattern="ame" path="/"
```

**修复：** 移除 `-n` 短标志（`StringP` → `String`），用户需使用 `--name`（双横线）。不影响 Linux/macOS 上的功能。

## Test plan

- [x] `go build ./...` 编译通过
- [x] `go test ./pkg/vfs/... -v` 20 个测试全部通过
- [x] `./bin/vkfs.exe ls /docs` 在 Windows 上正确输出文件列表
- [x] `./bin/vkfs.exe find / --name "*.md"` 在 Windows 上正确返回匹配文件
- [x] 修改对 Linux/macOS 零影响（`path` 包在 Unix 上行为与 `filepath` 一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)